### PR TITLE
Adds gravatar functionality

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+
+  # def gravatar_for(user, options = { size: 80})
+  #   email_address = user.email.downcase
+  #   hash = Digest::MD5.hexdigest(email_address)
+  #   size = options[:size]
+  #   gravatar_url = "https://www.gravatar.com/avatar/#{hash}?s=#{size}"
+  #   image_tag(gravatar_url, alt: user.username, class: "rounded shadow mx-auto d-block")
+  # end
+
 end


### PR DESCRIPTION
Just for fun; not meant to replace the current avatar system.
Thought this could be a cool integration considering I think we all have gravatar. After the project is finished, we can add our own profiles that grabs our avatars from gravatar automatically.

Syntax to add to a show page is: <%= gravatar_for @user, size: 200 %>