### PR TITLE
Disables sign ups until revisions

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -9,7 +9,8 @@ en:
       # When using html, text and mark won't be used.
       # html: '<abbr title="required">*</abbr>'
     error_notification:
-      default_message: "Please review the problems below:"
+      # default_message: "Please review the problems below:"
+      default_message: "Sign ups are temporarily disabled."
     # Examples
     # labels:
     #   defaults:


### PR DESCRIPTION
Until devise is properly implemented, changed the default error message when signing up.